### PR TITLE
Fixes compilation on Ubuntu 22.04.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
                -I$(NXDK_DIR)/lib/winapi \
                -I$(NXDK_DIR)/lib/xboxrt/vcruntime \
+               -U__STDC_NO_THREADS__ \
                -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt


### PR DESCRIPTION
Fixes https://github.com/abaire/nxdk_pgraph_tests/issues/91 by explicitly undefining `__STDC_NO_THREADS__`